### PR TITLE
feat: Implement GET /heroes/:heroId API endpoint

### DIFF
--- a/src/heroes/heroes.controller.ts
+++ b/src/heroes/heroes.controller.ts
@@ -1,4 +1,10 @@
-import { Controller, Get, HttpException, HttpStatus } from '@nestjs/common';
+import {
+  Controller,
+  Get,
+  HttpException,
+  HttpStatus,
+  Param,
+} from '@nestjs/common';
 import { HeroesService } from './heroes.service';
 import { Hero } from './interfaces/heroes.interface';
 
@@ -10,6 +16,18 @@ export class HeroesController {
   async getAllHeroes(): Promise<{ heroes: Hero[] }> {
     try {
       return await this.heroesService.getAllHeroes();
+    } catch (err) {
+      throw new HttpException(
+        'Unexpected error',
+        HttpStatus.INTERNAL_SERVER_ERROR,
+      );
+    }
+  }
+
+  @Get(':heroId')
+  async getHeroById(@Param('heroId') heroId: string): Promise<Hero> {
+    try {
+      return await this.heroesService.getHeroById(heroId);
     } catch (err) {
       throw new HttpException(
         'Unexpected error',

--- a/src/heroes/heroes.controller.ts
+++ b/src/heroes/heroes.controller.ts
@@ -29,10 +29,14 @@ export class HeroesController {
     try {
       return await this.heroesService.getHeroById(heroId);
     } catch (err) {
-      throw new HttpException(
-        'Unexpected error',
-        HttpStatus.INTERNAL_SERVER_ERROR,
-      );
+      if (err instanceof HttpException) {
+        throw new HttpException(err.getResponse(), err.getStatus());
+      } else {
+        throw new HttpException(
+          'Unexpected error',
+          HttpStatus.INTERNAL_SERVER_ERROR,
+        );
+      }
     }
   }
 }

--- a/src/heroes/heroes.service.ts
+++ b/src/heroes/heroes.service.ts
@@ -10,14 +10,15 @@ interface Hero {
 
 @Injectable()
 export class HeroesService {
-  private readonly apiUrl = 'https://hahow-recruit.herokuapp.com/heroes';
+  private readonly hahowHeroesAPIUrl: string =
+    'https://hahow-recruit.herokuapp.com/heroes';
 
   constructor(private readonly httpService: HttpService) {}
 
   async getAllHeroes(): Promise<{ heroes: Hero[] }> {
     try {
       const { data } = await firstValueFrom(
-        this.httpService.get<Hero[]>(this.apiUrl),
+        this.httpService.get<Hero[]>(this.hahowHeroesAPIUrl),
       );
       return { heroes: data };
     } catch (err) {

--- a/src/heroes/heroes.service.ts
+++ b/src/heroes/heroes.service.ts
@@ -26,4 +26,18 @@ export class HeroesService {
       throw new HttpException(err.response.data, err.response.status);
     }
   }
+
+  async getHeroById(heroId: string): Promise<Hero> {
+    try {
+      const hahowHeroAPIUrl = `${this.hahowHeroesAPIUrl}/${heroId}`;
+      const { data } = await firstValueFrom(
+        this.httpService.get<Hero>(hahowHeroAPIUrl),
+      );
+
+      return data;
+    } catch (err) {
+      console.error('getHeroById Service:', err.message);
+      throw err;
+    }
+  }
 }

--- a/src/heroes/heroes.service.ts
+++ b/src/heroes/heroes.service.ts
@@ -3,9 +3,9 @@ import { HttpService } from '@nestjs/axios';
 import { firstValueFrom } from 'rxjs';
 
 interface Hero {
-  readonly id: number;
+  readonly id: string;
   readonly name: string;
-  readonly image: number;
+  readonly image: string;
 }
 
 interface BackendErrorResponse {

--- a/src/heroes/heroes.service.ts
+++ b/src/heroes/heroes.service.ts
@@ -1,4 +1,4 @@
-import { HttpException, Injectable } from '@nestjs/common';
+import { HttpException, HttpStatus, Injectable } from '@nestjs/common';
 import { HttpService } from '@nestjs/axios';
 import { firstValueFrom } from 'rxjs';
 
@@ -6,6 +6,11 @@ interface Hero {
   readonly id: number;
   readonly name: string;
   readonly image: number;
+}
+
+interface BackendErrorResponse {
+  code: number;
+  message: string;
 }
 
 @Injectable()
@@ -31,10 +36,15 @@ export class HeroesService {
     try {
       const hahowHeroAPIUrl = `${this.hahowHeroesAPIUrl}/${heroId}`;
       const { data } = await firstValueFrom(
-        this.httpService.get<Hero>(hahowHeroAPIUrl),
+        this.httpService.get<Hero | BackendErrorResponse>(hahowHeroAPIUrl),
       );
 
-      return data;
+      // When status code == 200, but did not get the data, need to return the message
+      if ('code' in data) {
+        throw new HttpException('Try it again', HttpStatus.OK);
+      }
+
+      return <Hero>data;
     } catch (err) {
       console.error('getHeroById Service:', err.message);
       throw err;

--- a/src/heroes/interfaces/heroes.interface.ts
+++ b/src/heroes/interfaces/heroes.interface.ts
@@ -1,5 +1,5 @@
 export interface Hero {
-  readonly id: number;
+  readonly id: string;
   readonly name: string;
-  readonly image: number;
+  readonly image: string;
 }


### PR DESCRIPTION
# What

1. What did you do?
- Rename apiUrl to hahowHeroesAPIUrl
- Implement GET /heroes/:heroId API endpoint
- Handle edge case for GET /heroes/:heroId API
- Revert changes to id and image types in hero interface

# Why

1. Why did you do that?
- Rename apiUrl to hahowHeroesAPIUrl to improve readability and extensibility
- This feature allows clients to retrieve hero information by specifying the hero ID in the API request
- This enhancement ensures that the API handles the edge case gracefully and provides an appropriate response when data retrieval fails, even though the status code is 200
- The modification ensures consistency in the interface's property types and aligns them with the original specifications and requirements

