### PR TITLE
refactor: Modify heroes controller variable, use env variable for API url

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,2 +1,3 @@
 HAHOW_HEROES_API_URL="https://faker_api"
+HAHOW_AUTH_API_URL="https://faker_api/auth"
 PORT=3000

--- a/src/guards/auth.guard.ts
+++ b/src/guards/auth.guard.ts
@@ -1,13 +1,18 @@
 import { CanActivate, ExecutionContext, Injectable } from '@nestjs/common';
 import { HttpService } from '@nestjs/axios';
 import { firstValueFrom } from 'rxjs';
+import { ConfigService } from '@nestjs/config';
 
 @Injectable()
 export class AuthGuard implements CanActivate {
-  private readonly hahowAuthAPIUrl: string =
-    'https://hahow-recruit.herokuapp.com/auth';
+  private readonly hahowAuthAPIUrl: string;
 
-  constructor(private readonly httpService: HttpService) {}
+  constructor(
+    private readonly httpService: HttpService,
+    private readonly configService: ConfigService,
+  ) {
+    this.hahowAuthAPIUrl = configService.get<string>('HAHOW_AUTH_API_URL');
+  }
 
   async canActivate(context: ExecutionContext): Promise<boolean> {
     const request = context.switchToHttp().getRequest();

--- a/src/heroes/heroes.controller.ts
+++ b/src/heroes/heroes.controller.ts
@@ -18,7 +18,7 @@ export class HeroesController {
 
   @Get()
   @UseGuards(AuthGuard)
-  async getAllHeroes(@Req() req: Request): Promise<AllHeroes> {
+  async getHeroesWithOptionalProfiles(@Req() req: Request): Promise<AllHeroes> {
     try {
       if (req.isAuthorized) {
         return await this.heroesService.getAllHeroesWithProfiles();
@@ -34,7 +34,7 @@ export class HeroesController {
 
   @Get(':heroId')
   @UseGuards(AuthGuard)
-  async getHeroById(
+  async getHeroByIdWithOptionalProfiles(
     @Req() req: Request,
     @Param('heroId') heroId: number,
   ): Promise<Hero> {


### PR DESCRIPTION
# What

1. What did you do?
- Rename getAllHeroes and getHeroById
- Use env variable for Hahow auth API url

# Why

1. Why did you do that?
- The new method names provide clearer and more descriptive names, enhancing the readability and understanding of the codebase. The renaming reflects that the methods return heroes with optional profiles based on the authentication status
- By using environment variables, we decouple the API URL from the codebase, making it easier to switch between different environments (e.g., development, production) without modifying the code. It also enhances security by keeping sensitive information separate from the source code

